### PR TITLE
Improve counting of collections using getSize()

### DIFF
--- a/zray/zray.php
+++ b/zray/zray.php
@@ -217,19 +217,19 @@ class Magento {
 				$activeProductsCount = $productsCollection
 				->addAttributeToFilter('status', 1)
 				->addAttributeToFilter('visibility', 4)
-				->count();
+				->getSize();
 				
 				$disabledProductsCount = $productsCollection
 				->addAttributeToFilter('status', 0)
-				->count();
+				->getSize();
 				
 				$categoryCount = Mage::getModel('catalog/category')
 				->getCollection()
-				->count();
+				->getSize();
 			
-				/*$ordersCount = Mage::getModel('sales/order')
+				$ordersCount = Mage::getModel('sales/order')
 				->getCollection()
-				->count();*/
+				->getSize();
 				
 				
 				$productAttrs = Mage::getResourceModel('catalog/product_attribute_collection');


### PR DESCRIPTION
count() should not be used as it loads the collection and on big stores results in out of memory
